### PR TITLE
Add time estimate and center items up top.

### DIFF
--- a/client/src/components/favorite/favoriteMapDashboard.component.js
+++ b/client/src/components/favorite/favoriteMapDashboard.component.js
@@ -16,7 +16,7 @@ const ASPECT_RATIO = width / height;
 const LATITUDE_DELTA = 0.0922;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 let id = 1;
-
+console.log(height);
 export default class CustomMarkers extends React.Component {
   constructor(props) {
     super(props);
@@ -145,7 +145,10 @@ export default class CustomMarkers extends React.Component {
             longitude: this.props.geometry.location.lng
         },
         key: '0',
-      }]
+      }],
+      distance: 0,
+      elevation: 0,
+      estimatedTime: 0
     });
     id = 0;
   }
@@ -227,6 +230,20 @@ export default class CustomMarkers extends React.Component {
               lineJoin='round'/>
           )) : null}
         </MapView>
+        <View style={styles.infoContainer}>
+         <TouchableOpacity
+            onPress={this.toggleMilesKilometers.bind(this)}
+            style={styles.topBubble}
+          >
+            <Text>{this.state.displayMiles ? `${this.state.distance.toPrecision(2)} mi` : `${(this.state.distance*1.60934).toPrecision(2)} km`}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={this.toggleFeetMeters.bind(this)}
+            style={styles.topBubble}
+          >
+            <Text>{this.state.displayFeet ? `${Math.round(this.state.elevation*3.28084)} ft` : `${Math.round(this.state.elevation)} m`}</Text>
+          </TouchableOpacity>
+        </View>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             onPress={() => {
@@ -240,19 +257,6 @@ export default class CustomMarkers extends React.Component {
             style={styles.bubble}
           >
             <Text>Remove Last Pin</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            onPress={this.toggleMilesKilometers.bind(this)}
-            style={styles.bubble}
-          >
-            <Text>{this.state.displayMiles ? `${this.state.distance.toPrecision(2)} mi` : `${(this.state.distance*1.60934).toPrecision(2)} km`}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={this.toggleFeetMeters.bind(this)}
-            style={styles.bubble}
-          >
-            <Text>{this.state.displayFeet ? `${Math.round(this.state.elevation*3.28084)} ft` : `${Math.round(this.state.elevation)} m`}</Text>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => {
@@ -288,6 +292,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 18,
     paddingVertical: 12,
     borderRadius: 20,
+  },
+  topBubble: {
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+  },
+  infoContainer: {
+    flexDirection: 'row',
+    //marginVertical: 20,
+    marginRight: width - 150,
+    marginBottom: height - 200,
+    backgroundColor: 'transparent',
   },
   latlng: {
     width: 200,

--- a/client/src/components/favorite/favoriteMapDashboard.component.js
+++ b/client/src/components/favorite/favoriteMapDashboard.component.js
@@ -92,6 +92,16 @@ export default class CustomMarkers extends React.Component {
       });
   }
 
+  calculateEstimatedTime() {
+    var hours = ((this.state.elevation)/600 + (this.state.distance*1.60934)/5).toPrecision(2);
+    if (hours < 1) {
+      var minutes = Math.round(hours * 60);
+      return `${minutes} mins`;
+    } else {
+      return `${hours} hrs`;
+    }
+  }
+
   saveMappedTrail(removedPin = false) {
     var trailId = this.props.id;
     var pins = this.state.markers.map(marker => {
@@ -243,6 +253,11 @@ export default class CustomMarkers extends React.Component {
           >
             <Text>{this.state.displayFeet ? `${Math.round(this.state.elevation*3.28084)} ft` : `${Math.round(this.state.elevation)} m`}</Text>
           </TouchableOpacity>
+          <View
+            style={styles.topBubble}
+          >
+            <Text>{this.calculateEstimatedTime()}</Text>
+          </View>
         </View>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
@@ -301,7 +316,7 @@ const styles = StyleSheet.create({
   infoContainer: {
     flexDirection: 'row',
     //marginVertical: 20,
-    marginRight: width - 150,
+    marginRight: width - 250,
     marginBottom: height - 200,
     backgroundColor: 'transparent',
   },

--- a/client/src/components/favorite/favoriteMapDashboard.component.js
+++ b/client/src/components/favorite/favoriteMapDashboard.component.js
@@ -16,13 +16,14 @@ const ASPECT_RATIO = width / height;
 const LATITUDE_DELTA = 0.0922;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 let id = 1;
-console.log(height);
+
 export default class CustomMarkers extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       distance: 0,
       elevation: 0,
+      estimatedTime: 0,
       region: {
         latitude: this.props.geometry.location.lat,
         longitude: this.props.geometry.location.lng,
@@ -38,7 +39,6 @@ export default class CustomMarkers extends React.Component {
       }],
       displayMiles: true,
       displayFeet: true,
-      estimatedTime: 0
     };
     this.onMapPress = this.onMapPress.bind(this);
   }
@@ -254,7 +254,7 @@ export default class CustomMarkers extends React.Component {
             <Text>{this.state.displayFeet ? `${Math.round(this.state.elevation*3.28084)} ft` : `${Math.round(this.state.elevation)} m`}</Text>
           </TouchableOpacity>
           <View
-            style={styles.topBubble}
+            style={styles.estimatedTime}
           >
             <Text>{this.calculateEstimatedTime()}</Text>
           </View>
@@ -308,15 +308,21 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 20,
   },
+  estimatedTime: {
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    width: 90
+  },
   topBubble: {
     backgroundColor: 'rgba(255,255,255,0.7)',
     paddingHorizontal: 18,
     paddingVertical: 12,
+    width: 80
   },
   infoContainer: {
     flexDirection: 'row',
-    //marginVertical: 20,
-    marginRight: width - 250,
+    alignItems: 'center',
     marginBottom: height - 200,
     backgroundColor: 'transparent',
   },


### PR DESCRIPTION
I'm not sure what you all want to do about styling. Currently the distance and elevation gain buttons are clickable and will toggle mi/km and ft/m.  The estimated time is not clickable, but it will show minutes if under 1 hour, otherwise it will show hours like "1.5 hrs"