### PR TITLE
Added a comment about return value of dimensions.windowHeight()

### DIFF
--- a/client/src/components/style/dimensions.js
+++ b/client/src/components/style/dimensions.js
@@ -16,6 +16,9 @@ const dimensions = {
     return Platform.OS === 'ios'? 50 : 50 + StatusBar.currentHeight;
   },
 
+  // Note: this returns an object with the following shape:
+  // {width: 375, scale: 2, height: 667}
+  // We may want to change the name of this dimensions property.
   windowHeight: () => {
     return Dimensions.get('window');
   }


### PR DESCRIPTION
It's called windowHeight but it returns an object that includes not just height but width and scale as well.